### PR TITLE
vim.treesitter.query.get_node_text -> vim.treesitter.get_node_text

### DIFF
--- a/lua/nvim-mdlink.lua
+++ b/lua/nvim-mdlink.lua
@@ -267,7 +267,7 @@ M.find.link = function()
   local dest = nil
   for child, _ in node:iter_children() do
     if child:type() == "link_destination" then
-      dest = vim.treesitter.query.get_node_text(child, pos[1])
+      dest = vim.treesitter.get_node_text(child, pos[1])
       break
     end
   end


### PR DESCRIPTION
vim.treesitter.query.get_node_text() is deprecated, use vim.treesitter.get_node_text() instead. :help deprecated